### PR TITLE
Allow redirects to be set before the first entry save

### DIFF
--- a/controllers/RetourController.php
+++ b/controllers/RetourController.php
@@ -72,7 +72,7 @@ class RetourController extends BaseController
         $record->redirectDestUrl = craft()->request->getPost('redirectDestUrl', $record->redirectDestUrl);
         $record->redirectHttpCode = craft()->request->getPost('redirectHttpCode', $record->redirectHttpCode);
         $record->hitLastTime = DateTimeHelper::currentUTCDateTime();
-        $record->associatedEntryId = 0;
+        $record->associatedElementId = 0;
 
         if ($record->save())
         {

--- a/fieldtypes/RetourFieldType.php
+++ b/fieldtypes/RetourFieldType.php
@@ -133,14 +133,13 @@ class RetourFieldType extends BaseFieldType
             $result = new Retour_RedirectsFieldModel($value);
         }
         $result->redirectDestUrl = $this->element->url;
-        $result->associatedEntryId = $this->element->id;
         $result->locale = $this->element->locale;
         if ($result->redirectMatchType == "exactmatch")
             $result->redirectSrcUrl = '/' . ltrim($result->redirectSrcUrl, '/');
 
 /* -- Restore the default fields we don't let the user edit */
 
-        $oldRecord = craft()->retour->getRedirectByEntryId($this->element->id, $this->element->locale);
+        $oldRecord = craft()->retour->getRedirectByElementId($this->element->id, $this->element->locale);
 
         if ($oldRecord)
         {
@@ -158,7 +157,6 @@ class RetourFieldType extends BaseFieldType
         }
         $error = craft()->cache->flush();
         RetourPlugin::log("Cache flushed: " . print_r($error, true), LogLevel::Info, false);
-        craft()->retour->saveRedirect($result);
 
         return $result;
     } /* -- prepValueFromPost */
@@ -174,7 +172,7 @@ class RetourFieldType extends BaseFieldType
         if (!$value)
         {
             $value = new Retour_RedirectsFieldModel();
-            $result = craft()->retour->getRedirectByEntryId($this->element->id, $this->element->locale);
+            $result = craft()->retour->getRedirectByElementId($this->element->id, $this->element->locale);
             if ($result)
                 $value->setAttributes($result->getAttributes(), false);
             else
@@ -197,10 +195,14 @@ class RetourFieldType extends BaseFieldType
      */
     public function onAfterElementSave()
     {
-        $fieldHandle = $this->model->handle;
-        $this->prepValueFromPost(null);
+        $element = $this->element;
+        $field = $this->model;
+        $result = $element->getContent()->getAttribute($field->handle);
 
-        parent::onAfterElementSave();
+        $result->associatedElementId = $element->id;
+        craft()->retour->saveRedirect($result);
+
+        // $this->prepValueFromPost(null);
     }
 
 }

--- a/models/Retour_RedirectsModel.php
+++ b/models/Retour_RedirectsModel.php
@@ -31,7 +31,7 @@ class Retour_RedirectsModel extends BaseModel
             'hitCount'              => array(AttributeType::Number, 'default' => 0),
             'hitLastTime'           => array(AttributeType::DateTime, 'default' => DateTimeHelper::currentTimeForDb() ),
             'locale'                => array(AttributeType::String, 'default' => ''),
-            'associatedEntryId'     => array(AttributeType::Number, 'default' => 0)
+            'associatedElementId'   => array(AttributeType::Number, 'default' => 0)
         ));
     }
 

--- a/records/Retour_RedirectsRecord.php
+++ b/records/Retour_RedirectsRecord.php
@@ -39,7 +39,7 @@ class Retour_RedirectsRecord extends BaseRecord
             'hitLastTime'           => array(AttributeType::DateTime, 'default' => DateTimeHelper::currentTimeForDb() ),
             'locale'                => array(AttributeType::Locale, 'required' => true)
             /* defined in defineRelations()
-            'associatedEntryId'     => array(AttributeType::Number, 'default' => 0),
+            'associatedElementId'   => array(AttributeType::Number, 'default' => 0),
             */
         );
     }
@@ -50,7 +50,7 @@ class Retour_RedirectsRecord extends BaseRecord
     public function defineIndexes()
     {
         return array(
-            array('columns' => array('locale', 'associatedEntryId')),
+            array('columns' => array('locale', 'associatedElementId')),
             array('columns' => array('redirectSrcUrlParsed'), 'unique' => true)
         );
     }
@@ -62,7 +62,7 @@ class Retour_RedirectsRecord extends BaseRecord
     {
         return array(
             'locale'            => array(static::BELONGS_TO, 'LocaleRecord', 'locale', 'required' => true, 'onDelete' => static::CASCADE, 'onUpdate' => static::CASCADE),
-            'associatedEntry'   => array(static::BELONGS_TO, 'EntryRecord', 'required' => true, 'onDelete' => static::CASCADE)
+            'associatedElement' => array(static::BELONGS_TO, 'ElementRecord', 'required' => true, 'onDelete' => static::CASCADE),
         );
     }
 }

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -188,9 +188,9 @@ class RetourService extends BaseApplicationComponent
                         $error = $this->incrementRedirectHitCount($redirect);
                         RetourPlugin::log($redirect['redirectMatchType'] . " result: " . print_r($error, true), LogLevel::Info, false);
 
-/* -- If we're not associated with an EntryID, handle capture group replacement */
+/* -- If we're not associated with an ElementId, handle capture group replacement */
 
-                        if ($redirect['associatedEntryId'] == 0)
+                        if ($redirect['associatedElementId'] == 0)
                         {
                             $redirect['redirectDestUrl'] = preg_replace($matchRegEx, $redirect['redirectDestUrl'], $url);
                         }
@@ -236,7 +236,7 @@ class RetourService extends BaseApplicationComponent
             $redirect['hitCount'] = $redirect['hitCount'] + 1;
             $redirect['hitLastTime'] = DateTimeHelper::currentTimeForDb();
 
-            if ($redirect['associatedEntryId'])
+            if ($redirect['associatedElementId'])
                 $table = 'retour_redirects';
             else
                 $table= 'retour_static_redirects';
@@ -292,15 +292,15 @@ class RetourService extends BaseApplicationComponent
     } /* -- incrementStatistics */
 
 /**
- * @param  int $entryId The associated entryID
+ * @param  int $ElementId The associated ElementId
  * @param  string $locale  The locale
  * @return Mixed The resulting Redirect
  */
-    public function getRedirectByEntryId($entryId, $locale)
+    public function getRedirectByElementId($ElementId, $locale)
     {
-        $result = Retour_RedirectsRecord::model()->findByAttributes(array('associatedEntryId' => $entryId, 'locale' => $locale));
+        $result = Retour_RedirectsRecord::model()->findByAttributes(array('associatedElementId' => $ElementId, 'locale' => $locale));
         return $result;
-    } /* -- getRedirectByEntryId */
+    } /* -- getRedirectByElementId */
 
 /**
  * @param  int $id The redirect's id
@@ -320,7 +320,7 @@ class RetourService extends BaseApplicationComponent
     {
         if (isset($redirectsModel))
         {
-            $result = $this->getRedirectByEntryId($redirectsModel->associatedEntryId, $redirectsModel->locale);
+            $result = $this->getRedirectByElementId($redirectsModel->associatedElementId, $redirectsModel->locale);
             if ($result)
             {
                 $result->setAttributes($redirectsModel->getAttributes(), false);
@@ -333,17 +333,17 @@ class RetourService extends BaseApplicationComponent
     } /* -- saveRedirect */
 
 /**
- * @param  int $entryId The associated entryID
+ * @param  int $ElementId The associated ElementId
  * @param  string $locale  The locale
  */
-    public function deleteRedirectByEntryId($entryId, $locale)
+    public function deleteRedirectByElementId($ElementId, $locale)
     {
-        $result = $this->getRedirectByEntryId($entryId, $locale);
+        $result = $this->getRedirectByElementId($ElementId, $locale);
         if ($result)
         {
             $result->delete();
         }
-    } /* -- deleteRedirectByEntryId */
+    } /* -- deleteRedirectByElementId */
 
 /**
  * @param  Retour_RedirectsModel The redirect to create


### PR DESCRIPTION
If I add a redirect (using the fieldtype) to an unsaved entry, when I try to save it I get the database error below. If I save the entry once first and then enter the save redirect, it works fine.

````
CDbCommand failed to execute the SQL statement: SQLSTATE[HY000]: General error: 1364 Field 'associatedEntryId' doesn't have a default value. The SQL statement executed was: INSERT INTO `craft_retour_redirects` (`redirectSrcUrl`, `redirectSrcUrlParsed`, `redirectMatchType`, `redirectDestUrl`, `redirectHttpCode`, `hitCount`, `hitLastTime`, `uid`, `locale`, `dateUpdated`, `dateCreated`) VALUES (:yp0, :yp1, :yp2, :yp3, :yp4, :yp5, :yp6, :yp7, :yp8, :yp9, :yp10). Bound with :yp0='/award-winning-stories/', :yp1='/award-winning-stories/', :yp2='exactmatch', :yp3=NULL, :yp4=301, :yp5=0, :yp6='2016-05-10 15:51:44', :yp7='48d55536-9cf1-4f14-a253-201d8ebaaf29', :yp8='en_us', :yp9='2016-05-10 15:51:44', :yp10='2016-05-10 15:51:44'
````

I have taken a stab at fixing this. First, moved the save operation from `prepValueFromPost ` to `onAfterElementSave`. The element id is available at that point. Second, I standardized on associating those records with the *ElementId* instead of the *EntryId*. You had been using the two interchangeably, but the entry is not yet saved in `onAfterElementSave`, so it was throwing foreign key constraint errors.

I have done some testing and things seem to be working well with these changes, but I am sure there are use-cases that I don't know about and haven't tested yet. I also haven't written a migration yet to switch the `associatedEntry` relationship on the Retour_RedirectsRecord to `associatedElement`.