### PR TITLE
parse_url's path start with the slash.

### DIFF
--- a/fieldtypes/RetourFieldType.php
+++ b/fieldtypes/RetourFieldType.php
@@ -133,7 +133,7 @@ class RetourFieldType extends BaseFieldType
             $result = new Retour_RedirectsFieldModel($value);
         }
         $urlParts = parse_url($this->element->url);
-        $url = $urlParts['path'] ? '/' . $urlParts['path'] : $this->element->url;
+        $url = $urlParts['path'] ? $urlParts['path'] : $this->element->url;
         $result->redirectDestUrl = $url;
         $result->associatedElementId = $this->element->id;
         if ($this->model->translatable)


### PR DESCRIPTION
`craft_retour_redirects.redirectDestUrl` urls were getting saved as `//my-url`, which broke when redirecting.

It appears `parse_url` includes the slash, so there is no need to prepend it.
I suppose you could add it and trim it off, but in my tests its always there whenever `path` is defined.