### PR TITLE
Don't save a record if the redirectSrcUrlParsed is empty

### DIFF
--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -429,9 +429,9 @@ class RetourService extends BaseApplicationComponent
         if (isset($redirectsModel))
         {
 
-/* -- Don't try to create a redirect if one already exists for the redirectSrcUrl */
+/* -- Don't try to create a redirect if one already exists for the redirectSrcUrlParsed, or if empty */
 
-            if (!$this->getRedirectByRedirectSrcUrl($redirectsModel->redirectSrcUrlParsed, $redirectsModel->locale))
+            if ($redirectsModel->redirectSrcUrlParsed && !$this->getRedirectByRedirectSrcUrl($redirectsModel->redirectSrcUrlParsed, $redirectsModel->locale))
             {
                 $result = new Retour_RedirectsRecord;
                 $result->setAttributes($redirectsModel->getAttributes(), false);


### PR DESCRIPTION
Since it never makes sense to save an empty pattern.

Once dynamic values are parsed, an empty value is possible,
especially if the pattern contains an {%if object.myField %}...

Also/unrelated: was going to rename `getRedirectByRedirectSrcUrl` to `getRedirectByRedirectSrcUrlParsed`, but I'll leave that decision up to you.