### PR TITLE
Fix retourMatch hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ Some things to do, and ideas for potential features:
 
 ## Retour Changelog
 
+### 1.0.18 -- 2016.09.23
+
+* [Improved] Don't redirect to the welcome page if we're being installed via Console command
+* [Improved] Updated the README.md
+
 ### 1.0.17 -- 2016.08.31
 
 * [Improved] Query strings are now stripped from the incoming URI before redirect detection is done

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Some things to do, and ideas for potential features:
 
 ### 1.0.18 -- 2016.09.23
 
+* [Added] Added a config.php setting `createUriChangeRedirects` so that the URI-change redirects can be disabled on a per-environment basis
 * [Improved] Don't redirect to the welcome page if we're being installed via Console command
 * [Improved] Updated the README.md
 

--- a/RetourPlugin.php
+++ b/RetourPlugin.php
@@ -195,7 +195,7 @@ class RetourPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.0.17';
+        return '1.0.18';
     }
 
     /**
@@ -264,7 +264,8 @@ class RetourPlugin extends BasePlugin
 
 /* -- Show our "Welcome to Retour" message */
 
-        craft()->request->redirect(UrlHelper::getCpUrl('retour/welcome'));
++       if (!craft()->isConsole())
+            craft()->request->redirect(UrlHelper::getCpUrl('retour/welcome'));
     }
 
     /**

--- a/RetourPlugin.php
+++ b/RetourPlugin.php
@@ -103,7 +103,7 @@ class RetourPlugin extends BasePlugin
         craft()->on('entries.onBeforeSaveEntry', function(Event $e)
         {
             $this->originalUris = array();
-            if(!$e->params['isNewEntry'] && craft()->config->get("createStaticRedirects", "retour"))
+            if(!$e->params['isNewEntry'] && craft()->config->get("createUriChangeRedirects", "retour"))
             {
                 $entry = $e->params['entry'];
 
@@ -117,7 +117,7 @@ class RetourPlugin extends BasePlugin
 
         craft()->on('entries.onSaveEntry', function(Event $e)
         {
-            if (!$e->params['isNewEntry'] && craft()->config->get("createStaticRedirects", "retour"))
+            if (!$e->params['isNewEntry'] && craft()->config->get("createUriChangeRedirects", "retour"))
             {
                 $entry = $e->params['entry'];
                 $newUris = craft()->retour->getLocalizedUris($entry);

--- a/RetourPlugin.php
+++ b/RetourPlugin.php
@@ -264,7 +264,7 @@ class RetourPlugin extends BasePlugin
 
 /* -- Show our "Welcome to Retour" message */
 
-+       if (!craft()->isConsole())
+        if (!craft()->isConsole())
             craft()->request->redirect(UrlHelper::getCpUrl('retour/welcome'));
     }
 

--- a/config.php
+++ b/config.php
@@ -14,5 +14,5 @@ return array(
 /**
  * Controls whether Retour automatically creates static redirects when an entry's URI changes.
  */
-    "createStaticRedirects" => true,
+    "createUriChangeRedirects" => true,
 );

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,14 @@
 [
     {
+        "version": "1.0.18",
+        "downloadUrl": "https://github.com/nystudio107/retour/archive/master.zip",
+        "date": "2016-09-23T12:00:00-05:00",
+        "notes": [
+            "[Improved] Don't redirect to the welcome page if we're being installed via Console command",
+            "[Improved] Updated the README.md"
+        ]
+    },
+    {
         "version": "1.0.17",
         "downloadUrl": "https://github.com/nystudio107/retour/archive/master.zip",
         "date": "2016-08-31T12:00:00-05:00",

--- a/releases.json
+++ b/releases.json
@@ -4,6 +4,7 @@
         "downloadUrl": "https://github.com/nystudio107/retour/archive/master.zip",
         "date": "2016-09-23T12:00:00-05:00",
         "notes": [
+            "[Added] Added a config.php setting `createUriChangeRedirects` so that the URI-change redirects can be disabled on a per-environment basis",
             "[Improved] Don't redirect to the welcome page if we're being installed via Console command",
             "[Improved] Updated the README.md"
         ]

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -210,9 +210,9 @@ class RetourService extends BaseApplicationComponent
                     {
                         if (method_exists($plugin, "retourMatch"))
                         {
-                            $args = array(
+                            $args = array(array(
                                 'redirect' => &$redirect,
-                                );
+                            ));
                             $result = call_user_func_array(array($plugin, "retourMatch"), $args);
                             if ($result)
                             {


### PR DESCRIPTION
`call_user_func_array` takes an _indexed_ array for its arguments, so as you have it, `$args['redirect'] doesn't exist, and therefore the `$redirect` you're passing by reference isn't changeable as your notes say: https://github.com/nystudio107/retour#custom-match-functions-via-plugin

Looks like you just need to wrap it in an array, and all is well. 