### PR TITLE
Allow handling of 404s from { exit } tags encountered while rendering templates

### DIFF
--- a/RetourPlugin.php
+++ b/RetourPlugin.php
@@ -28,7 +28,8 @@ class RetourPlugin extends BasePlugin
 
         craft()->onException = function(\CExceptionEvent $event)
         {
-            if (($event->exception instanceof \CHttpException) && ($event->exception->statusCode == 404))
+            if ((($event->exception instanceof \CHttpException) && ($event->exception->statusCode == 404))  ||
+                (($event->exception->getPrevious() instanceof \CHttpException) && ($event->exception->getPrevious()->statusCode == 404)))
             {
                 if (craft()->request->isSiteRequest() && !craft()->request->isLivePreview())
                 {


### PR DESCRIPTION
`{ exit }` tags result in a `HttpException` wrapped in `Twig_Error_Runtime` exception which the current top-level conditional in the `onException` handler does not check for. 

This change checks for that situation. 

It might be desirable to configure this as a settable option so as to not change existing behavior.