### PR TITLE
Add trailing slashes to auto-gen static redirects if addTrailingSlashesToUrls

### DIFF
--- a/RetourPlugin.php
+++ b/RetourPlugin.php
@@ -133,6 +133,11 @@ class RetourPlugin extends BasePlugin
                     {
                         $record = new Retour_StaticRedirectsRecord;
 
+                        if (craft()->config->get('addTrailingSlashesToUrls'))
+                        {
+                            $oldUri = rtrim($oldUri, '/') . '/';
+                            $newUri = rtrim($newUri, '/') . '/';
+                        }
 
     /* -- Set the record attributes for our new auto-redirect */
 


### PR DESCRIPTION
This is related to #45 but for automatically created static redirects when the URI of an entry changes. 

I came across this being a huge issue when setting up a site to always have trailing slashes:
- `addTrailingSlashesToUrls` is `true`
- 301 redirects in place to add trailing slash when missing

in the above scenario the auto-created static redirects were never hit.

