### PR TITLE
Add locale check logic for the redirect

### DIFF
--- a/controllers/RetourController.php
+++ b/controllers/RetourController.php
@@ -155,7 +155,7 @@ class RetourController extends BaseController
 
 /* -- Set the record attributes, defaulting to the existing values for whatever is missing from the post data */
 
-        $record->locale = craft()->language;
+        $record->locale = craft()->request->getPost('redirectLocale', craft()->language);
         $record->redirectMatchType = craft()->request->getPost('redirectMatchType', $record->redirectMatchType);
         $record->redirectSrcUrl = craft()->request->getPost('redirectSrcUrl', $record->redirectSrcUrl);
         if (($record->redirectMatchType == "exactmatch") && ($record->redirectSrcUrl !=""))

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -590,7 +590,7 @@ public function getLocalizedUris($element=null)
  */
     function shouldMatchLocale()
     {
-        return defined(CRAFT_LOCALE);
+        return defined("CRAFT_LOCALE");
     } /* -- shouldMatchLocale */
 
 /**

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -180,7 +180,7 @@ class RetourService extends BaseApplicationComponent
 /* -- Do a straight up match */
 
                 case "exactmatch":
-                    if (strcasecmp($redirect['redirectSrcUrlParsed'], $url) === 0)
+                    if (strcasecmp($redirect['redirectSrcUrlParsed'], $url) === 0 && CRAFT_LOCALE == $redirect['locale'])
                     {
                         $error = $this->incrementRedirectHitCount($redirect);
                         RetourPlugin::log($redirectMatchType . " result: " . print_r($error, true), LogLevel::Info, false);
@@ -193,7 +193,7 @@ class RetourService extends BaseApplicationComponent
 
                 case "regexmatch":
                     $matchRegEx = "`" . $redirect['redirectSrcUrlParsed'] . "`i";
-                    if (preg_match($matchRegEx, $url) === 1)
+                    if (preg_match($matchRegEx, $url) === 1 && CRAFT_LOCALE == $redirect['locale'])
                     {
                         $error = $this->incrementRedirectHitCount($redirect);
                         RetourPlugin::log($redirectMatchType . " result: " . print_r($error, true), LogLevel::Info, false);

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -203,7 +203,7 @@ class RetourService extends BaseApplicationComponent
                             $error = $this->incrementRedirectHitCount($redirect);
                             RetourPlugin::log($redirectMatchType . " result: " . print_r($error, true), LogLevel::Info, false);
 
-    /* -- If we're not associated with an EntryID, handle capture group replacement */
+/* -- If we're not associated with an EntryID, handle capture group replacement */
 
                             if ($redirect['associatedElementId'] == 0)
                             {

--- a/templates/_edit.twig
+++ b/templates/_edit.twig
@@ -124,6 +124,28 @@
                 }) }}
             </div>
 
+            <div class="field">
+                <div class="heading">
+                    <label for= "redirectLocale">{{ "Redirect Local"|t}}</label>
+                    <div class="instructions"><p>{{ "Select the locale for this redirect." |t |raw}}</p></div>
+                </div>
+                {% set locales = craft.i18n.getSiteLocales %}
+                {% set localeOptions = {} %}
+                {% for locale in locales %}
+                    {% set localeId = locale.id %}
+                    {% set localeName = locale.name %}
+                    {% set localeOptions = localeOptions | merge({ (localeId) : localeName}) %}
+                {% endfor %}
+                {{ forms.selectField({
+                    fieldClass: 'nomarginfield',
+                    class: 'selectField',
+                    id: "redirectLocale",
+                    options: localeOptions,
+                    name: "redirectLocale",
+                    value: values.locale,
+                }) }}
+            </div>
+
 <!-- Needed for for Craft < 2.5 -->
 
         {% if craft.app.version < 2.5 %}

--- a/templates/_edit.twig
+++ b/templates/_edit.twig
@@ -123,19 +123,20 @@
                     value: values.redirectHttpCode,
                 }) }}
             </div>
-
+            
+            {% set locales = craft.i18n.getSiteLocales %}
+            {% if locales|length %}
+            {% set localeOptions = {} %}
+            {% for locale in locales %}
+                {% set localeId = locale.id %}
+                {% set localeName = locale.name %}
+                {% set localeOptions = localeOptions | merge({ (localeId) : localeName}) %}
+            {% endfor %}
             <div class="field">
                 <div class="heading">
                     <label for= "redirectLocale">{{ "Redirect Local"|t}}</label>
                     <div class="instructions"><p>{{ "Select the locale for this redirect." |t |raw}}</p></div>
                 </div>
-                {% set locales = craft.i18n.getSiteLocales %}
-                {% set localeOptions = {} %}
-                {% for locale in locales %}
-                    {% set localeId = locale.id %}
-                    {% set localeName = locale.name %}
-                    {% set localeOptions = localeOptions | merge({ (localeId) : localeName}) %}
-                {% endfor %}
                 {{ forms.selectField({
                     fieldClass: 'nomarginfield',
                     class: 'selectField',
@@ -145,6 +146,7 @@
                     value: values.locale,
                 }) }}
             </div>
+            {% endif %}
 
 <!-- Needed for for Craft < 2.5 -->
 

--- a/templates/redirects.twig
+++ b/templates/redirects.twig
@@ -58,7 +58,8 @@
                     <thead>
                         <th style="width: 25%" scope="col"><span class="sort-label">{{ "Legacy URL Pattern"|t }}</span></th>
                         <th style="width: 25%" scope="col"><span class="sort-label">{{ "Redirect To"|t }}</span></th>
-                        <th style="width: 15%" scope="col"><span class="sort-label">{{ "Pattern Match Type"|t }}</span></th>
+                        <th style="width: 5%" scope="col"><span class="sort-label">{{ "Locale"|t }}</span></th>
+                        <th style="width: 10%" scope="col"><span class="sort-label">{{ "Pattern Match Type"|t }}</span></th>
                         <th style="width: 10%" scope="col"><span class="sort-label">{{ "Redirect Type"|t }}</span></th>
                         <th style="width: 5%" scope="col"><span class="sort-label">{{ "Hits"|t }}</span></th>
                         <th style="width: 16%" scope="col"><span class="sort-label">{{ "Last Hit"|t }}</span></th>
@@ -70,6 +71,7 @@
                             <tr data-id="{{ redir.id }}" data-name="{{ redir.redirectSrcUrl }}">
                                 <td><a class="go" href="{{ url("retour/edit/" ~ redir.id) }}">{{ redir.redirectSrcUrl }}</a></td>
                                 <td>{{ redir.redirectDestUrl }}</td>
+                                <td>{{ redir.locale }}</td>
                                 <td>{{ matchesList[redir.redirectMatchType] }}</td>
                                 <td>{{ redir.redirectHttpCode }}</td>
                                 <td>{{ redir.hitCount }}</td>
@@ -98,7 +100,8 @@
                     <thead>
                         <th style="width: 25%" scope="col"><span class="sort-label">{{ "Legacy URL Pattern"|t }}</span></th>
                         <th style="width: 25%" scope="col"><span class="sort-label">{{ "Redirect To"|t }}</span></th>
-                        <th style="width: 15%" scope="col"><span class="sort-label">{{ "Pattern Match Type"|t }}</span></th>
+                        <th style="width: 5%" scope="col"><span class="sort-label">{{ "Locale"|t }}</span></th>
+                        <th style="width: 10%" scope="col"><span class="sort-label">{{ "Pattern Match Type"|t }}</span></th>
                         <th style="width: 10%" scope="col"><span class="sort-label">{{ "Redirect Type"|t }}</span></th>
                         <th style="width: 5%" scope="col"><span class="sort-label">{{ "Hits"|t }}</span></th>
                         <th style="width: 20%" scope="col"><span class="sort-label">{{ "Last Hit"|t }}</span></th>
@@ -111,6 +114,7 @@
                             <tr data-id="{{ redir.id }}" data-name="{{ redir.redirectSrcUrl }}">
                                 <td><a class="go" href="{{ associatedEntry.cpEditUrl }}">{{ redir.redirectSrcUrl }}</a></td>
                                 <td>{{ redir.redirectDestUrl }}</td>
+                                <td>{{ redir.locale }}</td>
                                 <td>{{ matchesList[redir.redirectMatchType] }}</td>
                                 <td>{{ redir.redirectHttpCode }}</td>
                                 <td>{{ redir.hitCount }}</td>
@@ -144,7 +148,7 @@ $('#static-redirects').dataTable({
   "sDom": '<"top"ilpf<"clear">>rt<"bottom"ilp<"clear">>',
   "sPaginationType": "full_numbers",
   "aaSorting": [[ 4, "desc" ]],
-  "aoColumns": [ null, null, null, { "sType": "num" }, { "sType": "num" }, { "sType": "date" }, null],
+  "aoColumns": [ null, null, null, null, { "sType": "num" }, { "sType": "num" }, { "sType": "date" }, null],
   "bLengthChange": false,
   "iDisplayLength": 20,
   "bInfo": true,
@@ -173,7 +177,7 @@ $('#entry-redirects').dataTable({
   "sDom": '<"top"ilpf<"clear">>rt<"bottom"ilp<"clear">>',
   "sPaginationType": "full_numbers",
   "aaSorting": [[ 4, "desc" ]],
-  "aoColumns": [ null, null, null, { "sType": "num" }, { "sType": "num" }, { "sType": "date" }],
+  "aoColumns": [ null, null, null, null, { "sType": "num" }, { "sType": "num" }, { "sType": "date" }],
   "bLengthChange": false,
   "iDisplayLength": 20,
   "bInfo": true,


### PR DESCRIPTION
Since Retour has already got locale fields in the database.
It makes sense to check for locale when check for redirect.

The locale fields is displayed on the list of redirects and can be edited as well.

![image](https://cloud.githubusercontent.com/assets/7004799/25463739/6ce9638c-2b37-11e7-8e99-f11284880e3d.png)

![image](https://cloud.githubusercontent.com/assets/7004799/25463747/871bd5aa-2b37-11e7-85bd-5c62c523fd13.png)
