### PR TITLE
Fixes issue with Retour calling UserSessionService in console mode

### DIFF
--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -305,7 +305,9 @@ class RetourService extends BaseApplicationComponent
                 if ($record->save()) {
                     $error = craft()->cache->flush();
                     RetourPlugin::log("Cache flushed: " . print_r($error, true), LogLevel::Info, false);
-                    craft()->userSession->setNotice(Craft::t('Retour Redirect saved.'));
+                    if (!craft()->isConsole()) {
+                        craft()->userSession->setNotice(Craft::t('Retour Redirect saved.'));
+                    }
                     $error = "";
 
                     // To prevent redirect loops, see if any static redirects have our destUrl as their srcUrl
@@ -319,7 +321,9 @@ class RetourService extends BaseApplicationComponent
                 } else {
                     $error = $record->getErrors();
                     RetourPlugin::log(print_r($error, true), LogLevel::Info, false);
-                    craft()->userSession->setError(Craft::t('Couldn’t save Retour Redirect.'));
+                    if (!craft()->isConsole()) {
+                        craft()->userSession->setError(Craft::t('Couldn’t save Retour Redirect.'));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Retour calls `craft()->userSession` in a couple of spots in RetourService, which throws an exception (`"Craft\ConsoleApp.session" is not defined.`) when Craft is running in console mode.