### PR TITLE
Add url to retourMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ In your main plugin class file, simply add this function:
      *                    'hitCount' => the number of times this redirect has been matched, and the redirect done in the browser
      *                    'hitLastTime' => the date and time of the when this redirect was matched
      *                    'locale' => the locale of this redirect
-     *                )
+     *                ),
+     *                'url' => the url to match
      *            );
      * @return bool Return true if it's a match, false otherwise
      */

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -236,6 +236,7 @@ class RetourService extends BaseApplicationComponent
                             $args = array(
                                 array(
                                     'redirect' => &$redirect,
+                                    'url' => $url,
                                 ),
                             );
                             $result = call_user_func_array(array($plugin, "retourMatch"), $args);


### PR DESCRIPTION
When I was trying to use a custom match function, I didn't see a way to actually test the incoming url since it wasn't being passed into `retourMatch()`. If I'm overlooking a different/better way to do this, please disregard.