### PR TITLE
create auto redirects for (child-)categories and child-entires

### DIFF
--- a/config.php
+++ b/config.php
@@ -18,6 +18,11 @@ return array(
     "createUriChangeRedirects" => true,
 
     /**
+     * Controls whether Retour automatically creates static redirects when an category's URI changes.
+     */
+    "createUriChangeRedirectsCategories" => true,
+
+    /**
      * How many stats should be stored
      */
     "statsStoredLimit" => 1000,

--- a/services/RetourService.php
+++ b/services/RetourService.php
@@ -529,7 +529,7 @@ class RetourService extends BaseApplicationComponent
                     if (craft()->config->get('addTrailingSlashesToUrls')) {
                         $url = rtrim($url, '/') . '/';
                     }
-                    $unsortedLocalizedUrls[$row['locale']] = $url;
+                    $unsortedLocalizedUris[$row['locale']] = $url;
                 }
 
                 $locales = craft()->i18n->getSiteLocales();


### PR DESCRIPTION
Cool function the auto generate redirects for entries, but we were missing that for the categories (and commerce products), so I decided to create this pull request.

- Added the setting `createUriChangeRedirectsCategories`
- Fixed a bug in the `getLocalizedUris` which was saving the localized urls in the wrong array
- Added the ability to auto generate category redirects based on the existing entries code
- Added an extra foreach so also child entries get auto redirects